### PR TITLE
fixed miss-sized image for monitor

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,6 +6,7 @@ body{
     background-position-x: center;
     background-position-y:center;
     color: white;
+    background-color: #083A6F;
 }
 h2{
     font-family: 'Pokemon Hollow';


### PR DESCRIPTION
- didn't check for image sizing on monitor (edge-case).
- set default background color to match image to cover.